### PR TITLE
feat: ロゴテキストをシンプルに変更

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ export default function Dashboard() {
           <div className="flex h-16 items-center border-b px-6">
             <Link href="/" className="flex items-center gap-2 font-bold text-lg text-primary">
               <LayoutGrid className="h-7 w-7" />
-              <span>エンタ管理システム</span>
+              <span>エンタ</span>
             </Link>
           </div>
           <nav className="flex-1 space-y-1.5 p-4">


### PR DESCRIPTION
## 変更内容
- ロゴテキストを「エンタ管理システム」から「エンタ」に変更

## 変更理由
- よりシンプルで覚えやすい名称に統一
- UIの見た目もスッキリ

## テスト
- [x] ローカルで表示確認済み
- [x] レスポンシブデザインの確認

## スクリーンショット
変更前：エンタ管理システム
変更後：エンタ