### PR TITLE
feat: 認証リダイレクト機能を追加

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { signIn, getSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -17,6 +17,8 @@ export default function LoginPage() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const callbackUrl = searchParams.get('callbackUrl') || '/'
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -35,7 +37,7 @@ export default function LoginPage() {
       } else {
         const session = await getSession()
         if (session?.user) {
-          router.push('/')
+          router.push(callbackUrl)
           router.refresh()
         }
       }

--- a/app/employees/page.tsx
+++ b/app/employees/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useSession } from 'next-auth/react'
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
 
 import Link from "next/link"
@@ -99,11 +100,21 @@ const allEmployees = [
 ]
 
 export default function EmployeesPage() {
+  const { data: session, status } = useSession()
   const [isSidebarOpen, setIsSidebarOpen] = useState(true)
   const [searchTerm, setSearchTerm] = useState("")
   const [departmentFilter, setDepartmentFilter] = useState<string[]>([])
 
   const departments = Array.from(new Set(allEmployees.map((e) => e.department)))
+
+  // Loading state while checking authentication
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div>読み込み中...</div>
+      </div>
+    )
+  }
 
   const filteredEmployees = allEmployees.filter((employee) => {
     const matchesSearch =

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,34 @@
+import { withAuth } from "next-auth/middleware"
+
+export default withAuth(
+  function middleware(req) {
+    // Middleware logic can be added here if needed
+  },
+  {
+    callbacks: {
+      authorized: ({ token, req }) => {
+        // Allow access to auth pages without token
+        if (req.nextUrl.pathname.startsWith('/auth/')) {
+          return true
+        }
+
+        // For all other protected routes, require a valid token
+        return !!token
+      },
+    },
+  }
+)
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api/auth (NextAuth API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - public files
+     */
+    '/((?!api/auth|_next/static|_next/image|favicon.ico|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.gif$|.*\\.svg$).*)',
+  ],
+}


### PR DESCRIPTION
## 概要
未認証ユーザーが保護されたページにアクセスした際に、自動的にログインページにリダイレクトする機能を追加しました。

## 実装内容
- ✅ NextAuth middlewareによる保護されたルートの実装
- ✅ 未認証ユーザーを自動的にログインページにリダイレクト
- ✅ ログイン後の元ページへの自動リダイレクト機能（callbackUrl）
- ✅ /employeesページに認証チェックを追加

## 動作確認方法
1. ログアウト状態で `/employees` にアクセス
2. 自動的にログインページ（`/auth/login?callbackUrl=%2Femployees`）にリダイレクトされることを確認
3. ログイン後、元の `/employees` ページに戻ることを確認

## セキュリティ向上
- 全ての保護されたページで認証チェックが自動実行
- API routes (`/api/auth/*`) や静的ファイルは除外
- 認証ページ (`/auth/*`) は認証不要でアクセス可能

## 技術詳細
- `middleware.ts`: NextAuth withAuth middlewareを使用
- `app/auth/login/page.tsx`: callbackUrl機能を追加
- `app/employees/page.tsx`: 認証状態の確認を追加

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)