### PR TITLE
feat: 企業用と個人用の分離されたログインページを実装

### DIFF
--- a/app/auth/corporate/login/page.tsx
+++ b/app/auth/corporate/login/page.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn, getSession, signOut } from 'next-auth/react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Building2, Loader2 } from 'lucide-react'
+
+export default function CorporateLoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const callbackUrl = searchParams.get('callbackUrl') || '/corporate/dashboard'
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    try {
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      })
+
+      if (result?.error) {
+        setError('メールアドレスまたはパスワードが正しくありません')
+      } else {
+        const session = await getSession()
+        if (session?.user) {
+          // Check if user is corporate type
+          const userType = (session.user as any)?.user_type
+          if (userType === 'corporate' || userType === 'admin') {
+            router.push(callbackUrl)
+            router.refresh()
+          } else {
+            setError('企業アカウントでログインしてください')
+            await signOut()
+          }
+        }
+      }
+    } catch (error) {
+      setError('ログイン中にエラーが発生しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="flex justify-center mb-4">
+            <div className="flex items-center gap-2">
+              <Building2 className="h-8 w-8 text-blue-600" />
+              <span className="text-2xl font-bold text-gray-900">エンタ</span>
+            </div>
+          </div>
+          <CardTitle className="text-2xl text-gray-900">企業ログイン</CardTitle>
+          <CardDescription className="text-gray-600">
+            広告主企業向けログインページ
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">企業メールアドレス</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={loading}
+                placeholder="company@example.com"
+                className="focus:border-blue-500 focus:ring-blue-500"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">パスワード</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={loading}
+                placeholder="パスワードを入力"
+                className="focus:border-blue-500 focus:ring-blue-500"
+              />
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full bg-blue-600 hover:bg-blue-700"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ログイン中...
+                </>
+              ) : (
+                '企業ダッシュボードにログイン'
+              )}
+            </Button>
+          </form>
+
+          <div className="mt-6 text-center space-y-4">
+            <p className="text-sm text-gray-600">
+              企業アカウントをお持ちでないですか？{' '}
+              <Link href="/auth/corporate/register" className="text-blue-600 hover:underline font-medium">
+                企業登録
+              </Link>
+            </p>
+
+            <div className="border-t pt-4">
+              <p className="text-sm text-gray-500 mb-2">アフィリエイターの方はこちら</p>
+              <Link
+                href="/auth/personal/login"
+                className="text-green-600 hover:underline text-sm font-medium"
+              >
+                個人ログインページ
+              </Link>
+            </div>
+
+            <div className="p-3 bg-blue-50 rounded-lg text-sm text-gray-700 border border-blue-200">
+              <p className="font-medium mb-1">デモ企業アカウント:</p>
+              <p>Email: admin@example.com</p>
+              <p>Password: admin123</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/auth/personal/login/page.tsx
+++ b/app/auth/personal/login/page.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn, getSession, signOut } from 'next-auth/react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { User, Loader2 } from 'lucide-react'
+
+export default function PersonalLoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const callbackUrl = searchParams.get('callbackUrl') || '/personal/dashboard'
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+
+    try {
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      })
+
+      if (result?.error) {
+        setError('メールアドレスまたはパスワードが正しくありません')
+      } else {
+        const session = await getSession()
+        if (session?.user) {
+          // Check if user is personal type
+          const userType = (session.user as any)?.user_type
+          if (userType === 'personal' || userType === 'admin') {
+            router.push(callbackUrl)
+            router.refresh()
+          } else {
+            setError('個人アカウントでログインしてください')
+            await signOut()
+          }
+        }
+      }
+    } catch (error) {
+      setError('ログイン中にエラーが発生しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-emerald-100 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="flex justify-center mb-4">
+            <div className="flex items-center gap-2">
+              <User className="h-8 w-8 text-green-600" />
+              <span className="text-2xl font-bold text-gray-900">エンタ</span>
+            </div>
+          </div>
+          <CardTitle className="text-2xl text-gray-900">個人ログイン</CardTitle>
+          <CardDescription className="text-gray-600">
+            アフィリエイター向けログインページ
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">メールアドレス</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={loading}
+                placeholder="your@example.com"
+                className="focus:border-green-500 focus:ring-green-500"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">パスワード</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={loading}
+                placeholder="パスワードを入力"
+                className="focus:border-green-500 focus:ring-green-500"
+              />
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full bg-green-600 hover:bg-green-700"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ログイン中...
+                </>
+              ) : (
+                'アフィリエイトダッシュボードにログイン'
+              )}
+            </Button>
+          </form>
+
+          <div className="mt-6 text-center space-y-4">
+            <p className="text-sm text-gray-600">
+              アカウントをお持ちでないですか？{' '}
+              <Link href="/auth/personal/register" className="text-green-600 hover:underline font-medium">
+                個人登録
+              </Link>
+            </p>
+
+            <div className="border-t pt-4">
+              <p className="text-sm text-gray-500 mb-2">企業の方はこちら</p>
+              <Link
+                href="/auth/corporate/login"
+                className="text-blue-600 hover:underline text-sm font-medium"
+              >
+                企業ログインページ
+              </Link>
+            </div>
+
+            <div className="p-3 bg-green-50 rounded-lg text-sm text-gray-700 border border-green-200">
+              <p className="font-medium mb-1">アフィリエイト収益確認・管理</p>
+              <p>成果報酬の詳細確認やアフィリエイトリンクの管理ができます</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,276 @@
+"use client"
+
+import Link from "next/link"
+import { useSession, signOut } from "next-auth/react"
+import {
+  Bell,
+  Award,
+  DollarSign,
+  Briefcase,
+  Users,
+  ClipboardList,
+  LineChart,
+  Home,
+  Settings,
+  ChevronLeft,
+  ChevronRight,
+  PlusCircle,
+  Search,
+  LayoutGrid,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { EmployeeRankingTable } from "@/components/employee-ranking-table"
+import { RecentTasks } from "@/components/recent-tasks"
+import { TaskNotifications } from "@/components/task-notifications"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Input } from "@/components/ui/input"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useState } from "react"
+
+export default function Dashboard() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
+  const { data: session, status } = useSession()
+
+  const handleLogout = () => {
+    signOut({ callbackUrl: '/auth/login' })
+  }
+
+  return (
+    <div className="flex min-h-screen w-full bg-background">
+      {isSidebarOpen && (
+        <aside className="fixed inset-y-0 left-0 z-20 hidden w-64 flex-col border-r bg-card sm:flex">
+          <div className="flex h-16 items-center border-b px-6">
+            <Link href="/" className="flex items-center gap-2 font-bold text-lg text-primary">
+              <LayoutGrid className="h-7 w-7" />
+              <span>エンタ</span>
+            </Link>
+          </div>
+          <nav className="flex-1 space-y-1.5 p-4">
+            <Link
+              href="/"
+              className="flex items-center gap-3 rounded-lg bg-primary/10 px-3 py-2.5 text-primary font-medium transition-all hover:bg-primary/20"
+            >
+              <Home className="h-5 w-5" />
+              ダッシュボード
+            </Link>
+            <Link
+              href="/tasks"
+              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
+            >
+              <ClipboardList className="h-5 w-5" />
+              業務管理
+            </Link>
+            <Link
+              href="/employees"
+              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
+            >
+              <Users className="h-5 w-5" />
+              社員一覧
+            </Link>
+            <Link
+              href="/reports"
+              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
+            >
+              <LineChart className="h-5 w-5" />
+              レポート
+            </Link>
+          </nav>
+          <div className="mt-auto p-4 border-t">
+            <Link
+              href="/settings"
+              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
+            >
+              <Settings className="h-5 w-5" />
+              設定
+            </Link>
+          </div>
+        </aside>
+      )}
+
+      <div className={`flex flex-1 flex-col ${isSidebarOpen ? "sm:pl-64" : ""}`}>
+        <header className="sticky top-0 z-10 flex h-16 items-center justify-between gap-4 border-b bg-background/80 backdrop-blur-md px-4 sm:px-6">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="sm:hidden text-muted-foreground"
+              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+            >
+              {isSidebarOpen ? <ChevronLeft className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
+              <span className="sr-only">Toggle sidebar</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hidden sm:inline-flex text-muted-foreground"
+              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+            >
+              {isSidebarOpen ? <ChevronLeft className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
+              <span className="sr-only">Toggle sidebar</span>
+            </Button>
+            <div className="relative flex-1 md:grow-0">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="search"
+                placeholder="全体検索..."
+                className="w-full rounded-lg bg-muted pl-8 md:w-[280px] lg:w-[380px] focus:shadow-focus"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative rounded-full text-muted-foreground hover:text-primary"
+            >
+              <Bell className="h-5 w-5" />
+              <span className="absolute right-0 top-0 flex h-2.5 w-2.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-orange-500"></span>
+              </span>
+              <span className="sr-only">通知</span>
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="relative h-9 w-9 rounded-full">
+                  <Avatar className="h-9 w-9 border-2 border-transparent hover:border-primary transition-colors">
+                    <AvatarImage src="/placeholder.svg?height=36&width=36" alt="User" />
+                    <AvatarFallback>
+                      {session?.user?.name ? session.user.name.charAt(0).toUpperCase() : 'U'}
+                    </AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel>
+                  <p className="text-sm font-bold leading-none">
+                    {session?.user?.name || 'ユーザー'}
+                  </p>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>プロフィール</DropdownMenuItem>
+                <DropdownMenuItem>設定</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleLogout}>ログアウト</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </header>
+
+        <main className="flex-1 space-y-6 p-2 sm:p-4 md:p-6 lg:p-8">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <h1 className="text-3xl font-bold tracking-tight">ダッシュボード</h1>
+            <Button size="lg" className="shadow-sm hover:shadow-md transition-shadow">
+              <PlusCircle className="mr-2 h-5 w-5" />
+              新規業務作成
+            </Button>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <Card className="shadow-subtle hover:shadow-lg transition-shadow duration-300">
+              <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+                <CardTitle className="text-sm font-medium text-muted-foreground">総業務件数 (今月)</CardTitle>
+                <Briefcase className="h-5 w-5 text-primary" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-bold">1,248</div>
+                <p className="text-xs text-green-600">+12.5% 先月比</p>
+              </CardContent>
+            </Card>
+            <Card className="shadow-subtle hover:shadow-lg transition-shadow duration-300">
+              <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+                <CardTitle className="text-sm font-medium text-muted-foreground">総売上金額 (今月)</CardTitle>
+                <DollarSign className="h-5 w-5 text-primary" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-bold">¥3,456,789</div>
+                <p className="text-xs text-green-600">+8.2% 先月比</p>
+              </CardContent>
+            </Card>
+            <Card className="shadow-subtle hover:shadow-lg transition-shadow duration-300">
+              <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+                <CardTitle className="text-sm font-medium text-muted-foreground">トップ社員 (今月)</CardTitle>
+                <Award className="h-5 w-5 text-yellow-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">田中 太郎</div>
+                <p className="text-xs text-muted-foreground">ポイント: 1,250</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Tabs defaultValue="ranking" className="mt-6">
+            <TabsList className="flex flex-row space-x-1 rounded-md bg-muted p-1 text-muted-foreground mb-4 overflow-x-auto">
+              <TabsTrigger
+                value="ranking"
+                className="flex-shrink-0 justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md"
+              >
+                社員ランキング
+              </TabsTrigger>
+              <TabsTrigger
+                value="tasks"
+                className="flex-shrink-0 justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md"
+              >
+                最近の業務
+              </TabsTrigger>
+              <TabsTrigger
+                value="notifications"
+                className="flex-shrink-0 justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md"
+              >
+                新着案件通知
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="ranking" className="mt-2">
+              {" "}
+              {/* Reduced margin for content when tabs are stacked */}
+              <Card className="shadow-subtle">
+                <CardHeader>
+                  <CardTitle>社員ランキング</CardTitle>
+                  <CardDescription>
+                    業務達成度に基づく社員のランキングです。クリックして社員詳細を確認できます。
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <EmployeeRankingTable />
+                </CardContent>
+              </Card>
+            </TabsContent>
+            <TabsContent value="tasks" className="mt-2">
+              <Card className="shadow-subtle">
+                <CardHeader>
+                  <CardTitle>最近の業務</CardTitle>
+                  <CardDescription>最近完了または進行中の業務の一覧です。</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <RecentTasks />
+                </CardContent>
+              </Card>
+            </TabsContent>
+            <TabsContent value="notifications" className="mt-2">
+              <Card className="shadow-subtle">
+                <CardHeader>
+                  <CardTitle>新着案件通知</CardTitle>
+                  <CardDescription>新しく登録された案件や重要な更新の通知です。</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <TaskNotifications />
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,276 +1,182 @@
-"use client"
+'use client'
 
-import Link from "next/link"
-import { useSession, signOut } from "next-auth/react"
-import {
-  Bell,
-  Award,
-  DollarSign,
-  Briefcase,
-  Users,
-  ClipboardList,
-  LineChart,
-  Home,
-  Settings,
-  ChevronLeft,
-  ChevronRight,
-  PlusCircle,
-  Search,
-  LayoutGrid,
-} from "lucide-react"
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Building2, User, LayoutGrid, ArrowRight, TrendingUp, Shield, Zap } from 'lucide-react'
 
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { EmployeeRankingTable } from "@/components/employee-ranking-table"
-import { RecentTasks } from "@/components/recent-tasks"
-import { TaskNotifications } from "@/components/task-notifications"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Input } from "@/components/ui/input"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { useState } from "react"
-
-export default function Dashboard() {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
-  const { data: session, status } = useSession()
-
-  const handleLogout = () => {
-    signOut({ callbackUrl: '/auth/login' })
-  }
-
+export default function LandingPage() {
   return (
-    <div className="flex min-h-screen w-full bg-background">
-      {isSidebarOpen && (
-        <aside className="fixed inset-y-0 left-0 z-20 hidden w-64 flex-col border-r bg-card sm:flex">
-          <div className="flex h-16 items-center border-b px-6">
-            <Link href="/" className="flex items-center gap-2 font-bold text-lg text-primary">
-              <LayoutGrid className="h-7 w-7" />
-              <span>エンタ</span>
-            </Link>
-          </div>
-          <nav className="flex-1 space-y-1.5 p-4">
-            <Link
-              href="/"
-              className="flex items-center gap-3 rounded-lg bg-primary/10 px-3 py-2.5 text-primary font-medium transition-all hover:bg-primary/20"
-            >
-              <Home className="h-5 w-5" />
-              ダッシュボード
-            </Link>
-            <Link
-              href="/tasks"
-              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
-            >
-              <ClipboardList className="h-5 w-5" />
-              業務管理
-            </Link>
-            <Link
-              href="/employees"
-              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
-            >
-              <Users className="h-5 w-5" />
-              社員一覧
-            </Link>
-            <Link
-              href="/reports"
-              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
-            >
-              <LineChart className="h-5 w-5" />
-              レポート
-            </Link>
-          </nav>
-          <div className="mt-auto p-4 border-t">
-            <Link
-              href="/settings"
-              className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-muted-foreground transition-all hover:text-primary hover:bg-primary/10"
-            >
-              <Settings className="h-5 w-5" />
-              設定
-            </Link>
-          </div>
-        </aside>
-      )}
-
-      <div className={`flex flex-1 flex-col ${isSidebarOpen ? "sm:pl-64" : ""}`}>
-        <header className="sticky top-0 z-10 flex h-16 items-center justify-between gap-4 border-b bg-background/80 backdrop-blur-md px-4 sm:px-6">
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="sm:hidden text-muted-foreground"
-              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-            >
-              {isSidebarOpen ? <ChevronLeft className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
-              <span className="sr-only">Toggle sidebar</span>
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="hidden sm:inline-flex text-muted-foreground"
-              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-            >
-              {isSidebarOpen ? <ChevronLeft className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
-              <span className="sr-only">Toggle sidebar</span>
-            </Button>
-            <div className="relative flex-1 md:grow-0">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                type="search"
-                placeholder="全体検索..."
-                className="w-full rounded-lg bg-muted pl-8 md:w-[280px] lg:w-[380px] focus:shadow-focus"
-              />
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100">
+      {/* Header */}
+      <header className="border-b bg-white/80 backdrop-blur-md">
+        <div className="container mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <LayoutGrid className="h-8 w-8 text-blue-600" />
+              <span className="text-2xl font-bold text-gray-900">エンタ</span>
+            </div>
+            <div className="flex items-center gap-4">
+              <Link href="/auth/login" className="text-gray-600 hover:text-gray-900">
+                統合ログイン
+              </Link>
             </div>
           </div>
+        </div>
+      </header>
 
-          <div className="flex items-center gap-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="relative rounded-full text-muted-foreground hover:text-primary"
-            >
-              <Bell className="h-5 w-5" />
-              <span className="absolute right-0 top-0 flex h-2.5 w-2.5">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-orange-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-orange-500"></span>
-              </span>
-              <span className="sr-only">通知</span>
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="relative h-9 w-9 rounded-full">
-                  <Avatar className="h-9 w-9 border-2 border-transparent hover:border-primary transition-colors">
-                    <AvatarImage src="/placeholder.svg?height=36&width=36" alt="User" />
-                    <AvatarFallback>
-                      {session?.user?.name ? session.user.name.charAt(0).toUpperCase() : 'U'}
-                    </AvatarFallback>
-                  </Avatar>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuLabel>
-                  <p className="text-sm font-bold leading-none">
-                    {session?.user?.name || 'ユーザー'}
-                  </p>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem>プロフィール</DropdownMenuItem>
-                <DropdownMenuItem>設定</DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleLogout}>ログアウト</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </header>
+      {/* Hero Section */}
+      <section className="py-20 px-4">
+        <div className="container mx-auto text-center">
+          <h1 className="text-5xl font-bold text-gray-900 mb-6">
+            アフィリエイト
+            <span className="text-blue-600">マーケティング</span>
+            プラットフォーム
+          </h1>
+          <p className="text-xl text-gray-600 mb-12 max-w-3xl mx-auto">
+            企業とアフィリエイターを繋ぐ、次世代のマーケティングプラットフォーム。
+            A8.netのような成果報酬型広告で、効果的なビジネス成長を実現します。
+          </p>
 
-        <main className="flex-1 space-y-6 p-2 sm:p-4 md:p-6 lg:p-8">
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-            <h1 className="text-3xl font-bold tracking-tight">ダッシュボード</h1>
-            <Button size="lg" className="shadow-sm hover:shadow-md transition-shadow">
-              <PlusCircle className="mr-2 h-5 w-5" />
-              新規業務作成
-            </Button>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            <Card className="shadow-subtle hover:shadow-lg transition-shadow duration-300">
-              <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
-                <CardTitle className="text-sm font-medium text-muted-foreground">総業務件数 (今月)</CardTitle>
-                <Briefcase className="h-5 w-5 text-primary" />
+          {/* Login Type Selection */}
+          <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto mb-16">
+            {/* Corporate Login */}
+            <Card className="group hover:shadow-2xl transition-all duration-300 border-2 hover:border-blue-500 bg-white">
+              <CardHeader className="text-center pb-4">
+                <div className="flex justify-center mb-4">
+                  <div className="p-4 bg-blue-100 rounded-full group-hover:bg-blue-200 transition-colors">
+                    <Building2 className="h-12 w-12 text-blue-600" />
+                  </div>
+                </div>
+                <CardTitle className="text-2xl text-gray-900">企業・広告主</CardTitle>
+                <CardDescription className="text-gray-600">
+                  商品・サービスを宣伝したい企業様
+                </CardDescription>
               </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold">1,248</div>
-                <p className="text-xs text-green-600">+12.5% 先月比</p>
+              <CardContent className="space-y-4">
+                <div className="space-y-2 text-sm text-gray-600">
+                  <div className="flex items-center gap-2">
+                    <TrendingUp className="h-4 w-4 text-blue-600" />
+                    <span>成果報酬型広告の配信</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Shield className="h-4 w-4 text-blue-600" />
+                    <span>詳細な成果レポート</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Zap className="h-4 w-4 text-blue-600" />
+                    <span>リアルタイム分析</span>
+                  </div>
+                </div>
+                <Link href="/auth/corporate/login" className="block w-full">
+                  <Button className="w-full bg-blue-600 hover:bg-blue-700 group-hover:scale-105 transition-transform">
+                    企業ログイン
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </Link>
+                <p className="text-xs text-center text-gray-500">
+                  <Link href="/auth/corporate/register" className="text-blue-600 hover:underline">
+                    企業登録はこちら
+                  </Link>
+                </p>
               </CardContent>
             </Card>
-            <Card className="shadow-subtle hover:shadow-lg transition-shadow duration-300">
-              <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
-                <CardTitle className="text-sm font-medium text-muted-foreground">総売上金額 (今月)</CardTitle>
-                <DollarSign className="h-5 w-5 text-primary" />
+
+            {/* Personal Login */}
+            <Card className="group hover:shadow-2xl transition-all duration-300 border-2 hover:border-green-500 bg-white">
+              <CardHeader className="text-center pb-4">
+                <div className="flex justify-center mb-4">
+                  <div className="p-4 bg-green-100 rounded-full group-hover:bg-green-200 transition-colors">
+                    <User className="h-12 w-12 text-green-600" />
+                  </div>
+                </div>
+                <CardTitle className="text-2xl text-gray-900">個人・アフィリエイター</CardTitle>
+                <CardDescription className="text-gray-600">
+                  商品を紹介して収益を得たい方
+                </CardDescription>
               </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold">¥3,456,789</div>
-                <p className="text-xs text-green-600">+8.2% 先月比</p>
-              </CardContent>
-            </Card>
-            <Card className="shadow-subtle hover:shadow-lg transition-shadow duration-300">
-              <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
-                <CardTitle className="text-sm font-medium text-muted-foreground">トップ社員 (今月)</CardTitle>
-                <Award className="h-5 w-5 text-yellow-500" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">田中 太郎</div>
-                <p className="text-xs text-muted-foreground">ポイント: 1,250</p>
+              <CardContent className="space-y-4">
+                <div className="space-y-2 text-sm text-gray-600">
+                  <div className="flex items-center gap-2">
+                    <TrendingUp className="h-4 w-4 text-green-600" />
+                    <span>豊富な商品ラインナップ</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Shield className="h-4 w-4 text-green-600" />
+                    <span>透明な収益レポート</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Zap className="h-4 w-4 text-green-600" />
+                    <span>即座に始められる</span>
+                  </div>
+                </div>
+                <Link href="/auth/personal/login" className="block w-full">
+                  <Button className="w-full bg-green-600 hover:bg-green-700 group-hover:scale-105 transition-transform">
+                    個人ログイン
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </Link>
+                <p className="text-xs text-center text-gray-500">
+                  <Link href="/auth/personal/register" className="text-green-600 hover:underline">
+                    個人登録はこちら
+                  </Link>
+                </p>
               </CardContent>
             </Card>
           </div>
+        </div>
+      </section>
 
-          <Tabs defaultValue="ranking" className="mt-6">
-            <TabsList className="flex flex-row space-x-1 rounded-md bg-muted p-1 text-muted-foreground mb-4 overflow-x-auto">
-              <TabsTrigger
-                value="ranking"
-                className="flex-shrink-0 justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md"
-              >
-                社員ランキング
-              </TabsTrigger>
-              <TabsTrigger
-                value="tasks"
-                className="flex-shrink-0 justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md"
-              >
-                最近の業務
-              </TabsTrigger>
-              <TabsTrigger
-                value="notifications"
-                className="flex-shrink-0 justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md"
-              >
-                新着案件通知
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="ranking" className="mt-2">
-              {" "}
-              {/* Reduced margin for content when tabs are stacked */}
-              <Card className="shadow-subtle">
-                <CardHeader>
-                  <CardTitle>社員ランキング</CardTitle>
-                  <CardDescription>
-                    業務達成度に基づく社員のランキングです。クリックして社員詳細を確認できます。
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <EmployeeRankingTable />
-                </CardContent>
-              </Card>
-            </TabsContent>
-            <TabsContent value="tasks" className="mt-2">
-              <Card className="shadow-subtle">
-                <CardHeader>
-                  <CardTitle>最近の業務</CardTitle>
-                  <CardDescription>最近完了または進行中の業務の一覧です。</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <RecentTasks />
-                </CardContent>
-              </Card>
-            </TabsContent>
-            <TabsContent value="notifications" className="mt-2">
-              <Card className="shadow-subtle">
-                <CardHeader>
-                  <CardTitle>新着案件通知</CardTitle>
-                  <CardDescription>新しく登録された案件や重要な更新の通知です。</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <TaskNotifications />
-                </CardContent>
-              </Card>
-            </TabsContent>
-          </Tabs>
-        </main>
-      </div>
+      {/* Features Section */}
+      <section className="py-16 bg-white">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">
+            なぜエンタが選ばれるのか
+          </h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            <div className="text-center">
+              <div className="p-4 bg-blue-100 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+                <TrendingUp className="h-8 w-8 text-blue-600" />
+              </div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">高い成果率</h3>
+              <p className="text-gray-600">
+                独自のマッチングアルゴリズムで、企業とアフィリエイターの最適な組み合わせを実現
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="p-4 bg-green-100 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+                <Shield className="h-8 w-8 text-green-600" />
+              </div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">安心・安全</h3>
+              <p className="text-gray-600">
+                厳格な審査プロセスと透明な取引システムで、安心してご利用いただけます
+              </p>
+            </div>
+            <div className="text-center">
+              <div className="p-4 bg-purple-100 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+                <Zap className="h-8 w-8 text-purple-600" />
+              </div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">簡単スタート</h3>
+              <p className="text-gray-600">
+                直感的なインターフェースで、初心者でもすぐにアフィリエイトを始められます
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="bg-gray-900 text-white py-8">
+        <div className="container mx-auto px-4 text-center">
+          <div className="flex items-center justify-center gap-2 mb-4">
+            <LayoutGrid className="h-6 w-6" />
+            <span className="text-xl font-bold">エンタ</span>
+          </div>
+          <p className="text-gray-400">
+            © 2024 エンタ. All rights reserved.
+          </p>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -61,6 +61,7 @@ export const authOptions: NextAuthOptions = {
               email: user.email,
               name: user.name,
               role: user.role,
+              user_type: user.user_type,
             }
           }
 
@@ -76,12 +77,14 @@ export const authOptions: NextAuthOptions = {
     async jwt({ token, user }) {
       if (user) {
         token.role = (user as any).role
+        token.user_type = (user as any).user_type
       }
       return token
     },
     async session({ session, token }) {
       if (session.user) {
         (session.user as any).role = token.role
+        (session.user as any).user_type = token.user_type
       }
       return session
     }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS public.users (
     email VARCHAR(255) UNIQUE NOT NULL,
     name VARCHAR(255),
     role VARCHAR(20) DEFAULT 'user' CHECK (role IN ('admin', 'user')),
+    user_type VARCHAR(20) DEFAULT 'personal' CHECK (user_type IN ('corporate', 'personal', 'admin')),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -26,8 +27,8 @@ CREATE TABLE IF NOT EXISTS public.employees (
 );
 
 -- Insert default admin user
-INSERT INTO public.users (email, name, role)
-VALUES ('admin@example.com', '管理者', 'admin')
+INSERT INTO public.users (email, name, role, user_type)
+VALUES ('admin@example.com', '管理者', 'admin', 'admin')
 ON CONFLICT (email) DO NOTHING;
 
 -- Insert sample employees


### PR DESCRIPTION
## 概要
A8.netのようなアフィリエイトポータルサイトとして、企業（広告主）と個人（アフィリエイター）の2つの異なるユーザータイプに対応した分離されたログインページを実装しました。

## 実装内容
- ✅ **データベース拡張**: user_typeカラムを追加（corporate/personal/admin）
- ✅ **企業用ログインページ**: `/auth/corporate/login` - 広告主企業向け
- ✅ **個人用ログインページ**: `/auth/personal/login` - アフィリエイター向け
- ✅ **認証設定更新**: NextAuth.jsでuser_type情報をセッションに含める
- ✅ **ランディングページ**: A8.net風のユーザータイプ選択画面
- ✅ **既存ダッシュボード移動**: `/dashboard`に移動

## 新しいページ構成
```
/ (ランディングページ)
├── /auth/corporate/login (企業ログイン)
├── /auth/personal/login (個人ログイン)
├── /dashboard (既存のダッシュボード)
└── /auth/login (統合ログイン - 後方互換性)
```

## デザイン特徴
- **企業用**: 青色テーマ、Building2アイコン、企業向けメッセージ
- **個人用**: 緑色テーマ、Userアイコン、アフィリエイター向けメッセージ
- **ランディング**: グラデーション背景、機能説明、ユーザータイプ選択

## 認証フロー
1. ユーザーがランディングページでユーザータイプを選択
2. 適切なログインページにリダイレクト
3. ログイン時にuser_typeをチェック
4. 不正なuser_typeの場合はエラー表示・強制ログアウト

## 技術詳細
- Supabaseデータベーススキーマ更新
- NextAuth.jsコールバック拡張
- TypeScript型安全性維持
- レスポンシブデザイン対応

## テスト方法
1. http://localhost:3000 でランディングページを確認
2. 企業ログイン・個人ログインそれぞれをテスト
3. 認証後の適切なリダイレクトを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)