### PR TITLE
トップページアクセス制限解除とLP文言・ロゴ・レスポンシブ修正

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Building2, User, LayoutGrid, ArrowRight } from 'lucide-react'
+import { Building2, User, Megaphone, ArrowRight } from 'lucide-react'
 
 export default function SignInPage() {
   return (
@@ -12,7 +12,7 @@ export default function SignInPage() {
         <CardHeader className="text-center">
           <div className="flex justify-center mb-4">
             <div className="flex items-center gap-2">
-              <LayoutGrid className="h-8 w-8 text-blue-600" />
+              <Megaphone className="h-8 w-8 text-blue-600" />
               <span className="text-2xl font-bold text-gray-900">エンタ</span>
             </div>
           </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,7 +16,7 @@ import {
   ChevronRight,
   PlusCircle,
   Search,
-  LayoutGrid,
+  Megaphone,
 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -51,7 +51,7 @@ export default function Dashboard() {
         <aside className="fixed inset-y-0 left-0 z-20 hidden w-64 flex-col border-r bg-card sm:flex">
           <div className="flex h-16 items-center border-b px-6">
             <Link href="/" className="flex items-center gap-2 font-bold text-lg text-primary">
-              <LayoutGrid className="h-7 w-7" />
+              <Megaphone className="h-7 w-7" />
               <span>エンタ</span>
             </Link>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,7 +167,7 @@ export default function LandingPage() {
       <footer className="bg-gray-900 text-white py-8">
         <div className="container mx-auto px-4 text-center">
           <div className="flex items-center justify-center gap-2 mb-4">
-            <LayoutGrid className="h-6 w-6" />
+            <Megaphone className="h-6 w-6" />
             <span className="text-xl font-bold">エンタ</span>
           </div>
           <p className="text-gray-400">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,11 +16,6 @@ export default function LandingPage() {
               <Megaphone className="h-8 w-8 text-blue-600" />
               <span className="text-2xl font-bold text-gray-900">エンタ</span>
             </div>
-            <div className="flex items-center gap-4">
-              <Link href="/auth/login" className="text-gray-600 hover:text-gray-900">
-                統合ログイン
-              </Link>
-            </div>
           </div>
         </div>
       </header>
@@ -28,12 +23,16 @@ export default function LandingPage() {
       {/* Hero Section */}
       <section className="py-20 px-4">
         <div className="container mx-auto text-center">
-          <h1 className="text-5xl font-bold text-gray-900 mb-6">
-            アフィリエイト<span className="text-blue-600">広告</span>サービス
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gray-900 mb-6 leading-tight">
+            <span className="block sm:inline">アフィリエイト</span>
+            <span className="text-blue-600">広告</span>
+            <span className="inline">サービス</span>
           </h1>
-          <p className="text-xl text-gray-600 mb-12 max-w-3xl mx-auto">
-            企業とアフィリエイターを繋ぐ、次世代のマーケティングプラットフォーム。
-            A8.netのような成果報酬型広告で、効果的なビジネス成長を実現します。
+          <p className="text-base sm:text-lg md:text-xl text-gray-600 mb-12 max-w-3xl mx-auto px-4">
+            企業とアフィリエイターを繋ぐ、<br className="sm:hidden" />
+            次世代のマーケティングプラットフォーム。<br className="hidden sm:block" />
+            A8.netのような成果報酬型広告で、<br className="sm:hidden" />
+            効果的なビジネス成長を実現します。
           </p>
 
           {/* Login Type Selection */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Building2, User, LayoutGrid, ArrowRight, TrendingUp, Shield, Zap } from 'lucide-react'
+import { Building2, User, Megaphone, ArrowRight, TrendingUp, Shield, Zap } from 'lucide-react'
 
 export default function LandingPage() {
   return (
@@ -13,7 +13,7 @@ export default function LandingPage() {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <LayoutGrid className="h-8 w-8 text-blue-600" />
+              <Megaphone className="h-8 w-8 text-blue-600" />
               <span className="text-2xl font-bold text-gray-900">エンタ</span>
             </div>
             <div className="flex items-center gap-4">
@@ -29,9 +29,7 @@ export default function LandingPage() {
       <section className="py-20 px-4">
         <div className="container mx-auto text-center">
           <h1 className="text-5xl font-bold text-gray-900 mb-6">
-            アフィリエイト
-            <span className="text-blue-600">マーケティング</span>
-            プラットフォーム
+            アフィリエイト<span className="text-blue-600">広告</span>サービス
           </h1>
           <p className="text-xl text-gray-600 mb-12 max-w-3xl mx-auto">
             企業とアフィリエイターを繋ぐ、次世代のマーケティングプラットフォーム。

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,8 +7,12 @@ export default withAuth(
   {
     callbacks: {
       authorized: ({ token, req }) => {
-        // Allow access to auth pages without token
-        if (req.nextUrl.pathname.startsWith('/auth/')) {
+        // Allow access to public pages without token
+        const publicPaths = ['/', '/auth/']
+        const pathname = req.nextUrl.pathname
+
+        // Check if the path is public
+        if (pathname === '/' || pathname.startsWith('/auth/')) {
           return true
         }
 


### PR DESCRIPTION
## Summary
トップページへのアクセス制限を解除し、LP文言・ロゴ・レスポンシブ表示を修正しました。

## 修正内容

### 1. トップページアクセス制限解除
- ✅ middleware.tsを修正して`/`を認証不要のパブリックページに設定

### 2. LP文言の短縮
- ✅ 「アフィリエイトマーケティングプラットフォーム」→「アフィリエイト広告サービス」に変更

### 3. ロゴアイコンの変更
- ✅ LayoutGrid → Megaphone（メガフォン）アイコンに変更
- ✅ 全ページ（LP、サインイン、ダッシュボード、フッター）で統一

### 4. レスポンシブ表示の改善
- ✅ SP版でのタイトル文言崩れを修正（適切な改行位置を設定）
- ✅ フォントサイズをデバイスサイズに応じて調整
- ✅ 統合ログインリンクを削除（未使用機能）

## Test plan
- [ ] http://localhost:3000/ へ認証なしでアクセスできることを確認
- [ ] SP版で文言が適切に表示されることを確認
- [ ] 全ページでロゴアイコンが統一されていることを確認
- [ ] レスポンシブ表示で文字が崩れないことを確認

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)