### PR TITLE
SP版ヒーローセクションの説明文削除でレイアウト改善

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,12 +28,6 @@ export default function LandingPage() {
             <span className="text-blue-600">広告</span>
             <span className="inline">サービス</span>
           </h1>
-          <p className="text-base sm:text-lg md:text-xl text-gray-600 mb-12 max-w-3xl mx-auto px-4">
-            企業とアフィリエイターを繋ぐ、<br className="sm:hidden" />
-            次世代のマーケティングプラットフォーム。<br className="hidden sm:block" />
-            A8.netのような成果報酬型広告で、<br className="sm:hidden" />
-            効果的なビジネス成長を実現します。
-          </p>
 
           {/* Login Type Selection */}
           <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto mb-16">


### PR DESCRIPTION
## Summary
SP版でのレイアウト崩れを根本的に解決するため、ヒーローセクションの説明文を削除してスッキリしたデザインに改善しました。

## 修正内容
- ✅ 長すぎた説明文を完全に削除
- ✅ タイトル直下にログイン選択カードを配置
- ✅ SP版でのレイアウト問題を根本的に解決
- ✅ よりシンプルで分かりやすいUI

## Before/After
**Before**: 長い説明文がSP版で崩れて表示
**After**: タイトル→ログイン選択カードの直接的なフロー

Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)